### PR TITLE
Added @ prefix to PropertyName if it is a keyword or digit

### DIFF
--- a/NuGetSpecs/GenericModelGenerator.tt
+++ b/NuGetSpecs/GenericModelGenerator.tt
@@ -171,10 +171,22 @@ public class Tables : List<Table>
 
 static Regex rxCleanUp = new Regex(@"[^\w\d_]", RegexOptions.Compiled);
 
+static string[] cs_keywords = { "abstract", "event", "new", "struct", "as", "explicit", "null", 
+	"switch", "base", "extern", "object", "this", "bool", "false", "operator", "throw", 
+	"break", "finally", "out", "true", "byte", "fixed", "override", "try", "case", "float", 
+	"params", "typeof", "catch", "for", "private", "uint", "char", "foreach", "protected", 
+	"ulong", "checked", "goto", "public", "unchecked", "class", "if", "readonly", "unsafe", 
+	"const", "implicit", "ref", "ushort", "continue", "in", "return", "using", "decimal", 
+	"int", "sbyte", "virtual", "default", "interface", "sealed", "volatile", "delegate", 
+	"internal", "short", "void", "do", "is", "sizeof", "while", "double", "lock", 
+	"stackalloc", "else", "long", "static", "enum", "namespace", "string" };
+
 static Func<string, string> CleanUp = (str) =>
 {
 	str = rxCleanUp.Replace(str, "_");
-	if (char.IsDigit(str[0])) str = "_" + str;
+
+	if (char.IsDigit(str[0]) || cs_keywords.Contains(str))
+		str = "@" + str;
 	
     return str;
 };


### PR DESCRIPTION
Based on what I saw PetaPoco doing to fix property names that were C#
keywords. I changed the cleanup logic to add an @ symbol to the property
name so that it could be left untouched and compile correctly without
having to change the name in any way.