### PR TITLE
Include column and table description; sort tables in order

### DIFF
--- a/Dapper.FastCrud.sln
+++ b/Dapper.FastCrud.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		NuGetSpecs\Dapper.FastCrud.ModelGenerator.nuspec = NuGetSpecs\Dapper.FastCrud.ModelGenerator.nuspec
 		NuGetSpecs\Dapper.FastCrud.nuspec = NuGetSpecs\Dapper.FastCrud.nuspec
+		NuGetSpecs\GenericModelGenerator.tt = NuGetSpecs\GenericModelGenerator.tt
 		global.json = global.json
 	EndProjectSection
 EndProject

--- a/NuGetSpecs/GenericModelGenerator.tt
+++ b/NuGetSpecs/GenericModelGenerator.tt
@@ -99,9 +99,9 @@ string[] ExcludeTablePrefixes = new string[]{};
 
 public class Table
 {
-    public List<Column> Columns;	
+    public List<Column> Columns;
 	public List<Key> InnerKeys = new List<Key>();
-    public List<Key> OuterKeys = new List<Key>(); 
+    public List<Key> OuterKeys = new List<Key>();
     public string Name;
 	public string Schema;
 	public bool IsView;
@@ -153,7 +153,7 @@ public class Tables : List<Table>
 	public Tables()
 	{
 	}
-	
+
 	public Table GetTable(string tableName)
 	{
 		return this.Single(x=>string.Compare(x.Name, tableName, true)==0);
@@ -175,15 +175,15 @@ static Func<string, string> CleanUp = (str) =>
 {
 	str = rxCleanUp.Replace(str, "_");
 	if (char.IsDigit(str[0])) str = "_" + str;
-	
+
     return str;
 };
 
 string CheckNullable(Column col)
 {
     string result="";
-    if(col.IsNullable && 
-		col.PropertyType !="byte[]" && 
+    if(col.IsNullable &&
+		col.PropertyType !="byte[]" &&
 		col.PropertyType !="string" &&
 		col.PropertyType !="Microsoft.SqlServer.Types.SqlGeography" &&
 		col.PropertyType !="Microsoft.SqlServer.Types.SqlGeometry"
@@ -197,15 +197,15 @@ string GetConnectionString(ref string connectionStringName, out string providerN
     var _CurrentProject = GetCurrentProject();
 
 	providerName=null;
-    
+
     string result="";
     ExeConfigurationFileMap configFile = new ExeConfigurationFileMap();
     configFile.ExeConfigFilename = GetConfigPath();
 
     if (string.IsNullOrEmpty(configFile.ExeConfigFilename))
         throw new ArgumentNullException("The project does not contain App.config or Web.config file.");
-    
-    
+
+
     var config = System.Configuration.ConfigurationManager.OpenMappedExeConfiguration(configFile, ConfigurationUserLevel.None);
     var connSection=config.ConnectionStrings;
 
@@ -219,7 +219,7 @@ string GetConnectionString(ref string connectionStringName, out string providerN
 			connectionStringName = connSection.ConnectionStrings[connSection.ConnectionStrings.Count-1].Name;
             result=connSection.ConnectionStrings[connSection.ConnectionStrings.Count-1].ConnectionString;
             providerName=connSection.ConnectionStrings[connSection.ConnectionStrings.Count-1].ProviderName;
-        }            
+        }
     }
     else
     {
@@ -236,7 +236,7 @@ string GetConnectionString(ref string connectionStringName, out string providerN
 
 //	if (String.IsNullOrEmpty(providerName))
 //		providerName="System.Data.SqlClient";
-    
+
     return result;
 }
 
@@ -254,13 +254,13 @@ void InitConnectionString()
 			//have to replace it
 			string dataFilePath=GetDataDirectory();
 			_connectionString=_connectionString.Replace("|DataDirectory|",dataFilePath);
-		}    
+		}
 	}
 }
 
 public string ConnectionString
 {
-    get 
+    get
     {
 		InitConnectionString();
         return _connectionString;
@@ -269,7 +269,7 @@ public string ConnectionString
 
 public string ProviderName
 {
-    get 
+    get
     {
 		InitConnectionString();
         return _providerName;
@@ -281,19 +281,19 @@ public EnvDTE.Project GetCurrentProject()  {
     IServiceProvider _ServiceProvider = (IServiceProvider)Host;
     if (_ServiceProvider == null)
         throw new Exception("Host property returned unexpected value (null)");
-	
+
     EnvDTE.DTE dte = (EnvDTE.DTE)_ServiceProvider.GetService(typeof(EnvDTE.DTE));
     if (dte == null)
         throw new Exception("Unable to retrieve EnvDTE.DTE");
-	
+
     Array activeSolutionProjects = (Array)dte.ActiveSolutionProjects;
     if (activeSolutionProjects == null)
         throw new Exception("DTE.ActiveSolutionProjects returned null");
-	
+
     EnvDTE.Project dteProject = (EnvDTE.Project)activeSolutionProjects.GetValue(0);
     if (dteProject == null)
         throw new Exception("DTE.ActiveSolutionProjects[0] returned null");
-	
+
     return dteProject;
 
 }
@@ -343,12 +343,12 @@ static string Pluralize(string word)
 	var pluralWord = System.Data.Entity.Design.PluralizationServices.PluralizationService.CreateService(System.Globalization.CultureInfo.GetCultureInfo("en-us")).Pluralize(word);
 	return pluralWord;
 }
-		
+
 static string RemoveTablePrefixes(string word)
 {
 	var cleanword = word;
-	if(cleanword.StartsWith("tbl_")) cleanword = cleanword.Replace("tbl_",""); 
-	if(cleanword.StartsWith("tbl")) cleanword = cleanword.Replace("tbl",""); 
+	if(cleanword.StartsWith("tbl_")) cleanword = cleanword.Replace("tbl_","");
+	if(cleanword.StartsWith("tbl")) cleanword = cleanword.Replace("tbl","");
 	cleanword = cleanword.Replace("_","");
 	return cleanword;
 }
@@ -401,14 +401,14 @@ Tables LoadTables()
 		Tables result;
 		using(var conn=_factory.CreateConnection())
 		{
-			conn.ConnectionString=ConnectionString;         
+			conn.ConnectionString=ConnectionString;
 			conn.Open();
-        
+
 			SchemaReader reader=null;
-        
+
 			// Assume SQL Server
 			reader=new SqlServerSchemaReader();
-			
+
 			reader.outer=this;
 			result=reader.ReadSchema(conn, _factory);
 
@@ -459,7 +459,7 @@ Tables LoadTables()
 		return new Tables();
 	}
 
-        
+
 }
 
 abstract class SchemaReader
@@ -479,7 +479,7 @@ class SqlServerSchemaReader : SchemaReader
 	public override Tables ReadSchema(DbConnection connection, DbProviderFactory factory)
 	{
 		var result=new Tables();
-		
+
 		_connection=connection;
 		_factory=factory;
 
@@ -500,8 +500,8 @@ class SqlServerSchemaReader : SchemaReader
 					tbl.Schema=rdr["TABLE_SCHEMA"].ToString();
 					tbl.IsView=string.Compare(rdr["TABLE_TYPE"].ToString(), "View", true)==0;
 					tbl.CleanName=CleanUp(tbl.Name);
-					if(tbl.CleanName.StartsWith("tbl_")) tbl.CleanName = tbl.CleanName.Replace("tbl_",""); 
-					if(tbl.CleanName.StartsWith("tbl")) tbl.CleanName = tbl.CleanName.Replace("tbl",""); 
+					if(tbl.CleanName.StartsWith("tbl_")) tbl.CleanName = tbl.CleanName.Replace("tbl_","");
+					if(tbl.CleanName.StartsWith("tbl")) tbl.CleanName = tbl.CleanName.Replace("tbl","");
 					tbl.CleanName = tbl.CleanName.Replace("_","");
 					tbl.ClassName=Singularize(RemoveTablePrefixes(tbl.CleanName));
 
@@ -513,17 +513,17 @@ class SqlServerSchemaReader : SchemaReader
 		foreach (var tbl in result)
 		{
 			tbl.Columns=LoadColumns(tbl);
-		            
+
 			// Mark the primary keys
 			var primaryKeys=GetPKs(tbl.Name).Select(pk => pk.ToLower().Trim());
 			foreach(var pkColumn in tbl.Columns.Where( tblCol => primaryKeys.Any(pk => pk == tblCol.Name.ToLower().Trim()))){
-				pkColumn.IsPK = true;	
+				pkColumn.IsPK = true;
 			}
 
 			// Mark the columns with default columns
 			var defaultCols=GetColumnsWithDefaultValues(tbl.Name).Select(pk => pk.ToLower().Trim());
 			foreach(var pkColumn in tbl.Columns.Where( tblCol => defaultCols.Any(pk => pk == tblCol.Name.ToLower().Trim()))){
-				pkColumn.HasDefaultValue = true;	
+				pkColumn.HasDefaultValue = true;
 			}
 
 			try
@@ -541,18 +541,18 @@ class SqlServerSchemaReader : SchemaReader
 				WriteLine("");
 		    }
 		}
-	    
+
 
 		return result;
 	}
-	
+
 	DbConnection _connection;
 	DbProviderFactory _factory;
-	
+
 
 	List<Column> LoadColumns(Table tbl)
 	{
-	
+
 		using (var cmd=_factory.CreateCommand())
 		{
 			cmd.Connection=_connection;
@@ -650,7 +650,7 @@ class SqlServerSchemaReader : SchemaReader
 	}
 
 	List<string> GetPKs(string table){
-		
+
 		string sql=@"SELECT c.name AS ColumnName
                 FROM sys.indexes AS i 
                 INNER JOIN sys.index_columns AS ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id 
@@ -677,13 +677,13 @@ class SqlServerSchemaReader : SchemaReader
 					pks.Add(rdr["ColumnName"].ToString());
 				}
 			}
-		}	         
-		
+		}
+
 		return pks;
 	}
 
 	List<string> GetColumnsWithDefaultValues(string table){
-		
+
 		string sql=@"SELECT d.ColumnName FROM
 						(SELECT c.name as ColumnName, object_definition(c.default_object_id) AS DefaultDefinition
 						FROM   sys.columns as c
@@ -710,16 +710,16 @@ class SqlServerSchemaReader : SchemaReader
 					defaultCols.Add(rdr["ColumnName"].ToString());
 				}
 			}
-		}	         
-		
+		}
+
 		return defaultCols;
 	}
 
-	
+
 	string GetPropertyType(string sqlType)
 	{
 		string sysType="string";
-		switch (sqlType) 
+		switch (sqlType)
 		{
 			case "bigint":
 				sysType = "long";
@@ -778,7 +778,9 @@ class SqlServerSchemaReader : SchemaReader
 
 	const string TABLE_SQL=@"SELECT *
 		FROM  INFORMATION_SCHEMA.TABLES
-		WHERE TABLE_TYPE='BASE TABLE' OR TABLE_TYPE='VIEW'";
+		WHERE TABLE_TYPE='BASE TABLE' OR TABLE_TYPE='VIEW'
+		ORDER BY TABLE_SCHEMA, TABLE_NAME
+		";
 
 	const string COLUMN_SQL=@"SELECT 
 			TABLE_CATALOG AS [Database],
@@ -824,7 +826,7 @@ class SqlServerSchemaReader : SchemaReader
 		ON pt.referenced_column_id = rc.column_id
 		AND pt.referenced_object_id = rc.[object_id]
 		WHERE pt.referenced_object_id = OBJECT_ID(@tableName);";
-	  
+
 }
 
 #>

--- a/NuGetSpecs/GenericModelGenerator.tt
+++ b/NuGetSpecs/GenericModelGenerator.tt
@@ -42,14 +42,18 @@ foreach(Table tbl in tables.Where(t=> !t.Ignore)){
 		if(IsExcluded(tbl.Schema, tbl.Name, ExcludeTablePrefixes)) continue;
 #>
     /// <summary>
-    /// A class which represents the <#=tbl.Name#> <#=(tbl.IsView)?"view":"table"#>.
+    /// Represents the <#=tbl.Name#> <#=(tbl.IsView)?"view":"table"#><#=String.IsNullOrEmpty(tbl.Description)?"":" ("+tbl.Description+")"#>.
     /// </summary>
 	[Table("<#=tbl.Name#>")]
 	public partial class <#=tbl.ClassName#>
 	{
 <#foreach(Column col in from c in tbl.Columns where !c.Ignore select c)
 {#>
-	<# if (col.IsPK) { #>
+		/// <summary>
+		/// <#=col.Description#>
+		/// </summary>
+	<#
+	if (col.IsPK) { #>
 	[Key]
 	<#}
 	if(col.IsComputed) { #>
@@ -109,6 +113,7 @@ public class Table
     public string ClassName;
 	public string SequenceName;
 	public bool Ignore;
+	public string Description;
 
 	public Column GetColumn(string columnName)
 	{
@@ -137,6 +142,7 @@ public class Column
 	public bool IsComputed;
 	public bool Ignore;
 	public bool IsGeneratedUniqueIdentifier;
+	public string Description;
 }
 
 public class Key
@@ -504,6 +510,7 @@ class SqlServerSchemaReader : SchemaReader
 					if(tbl.CleanName.StartsWith("tbl")) tbl.CleanName = tbl.CleanName.Replace("tbl","");
 					tbl.CleanName = tbl.CleanName.Replace("_","");
 					tbl.ClassName=Singularize(RemoveTablePrefixes(tbl.CleanName));
+					tbl.Description=rdr["TABLE_DESCRIPTION"] as string;
 
 					result.Add(tbl);
 				}
@@ -581,6 +588,7 @@ class SqlServerSchemaReader : SchemaReader
 					col.IsNullable=rdr["IsNullable"].ToString()=="YES";
 					col.IsAutoIncrement=((int)rdr["IsIdentity"])==1;
 					col.IsGeneratedUniqueIdentifier = rdr["DefaultSetting"].ToString().ToLower().Trim(' ','(',')')=="newid";
+					col.Description = rdr["Description"] as string ?? ((rdr["ColumnName"] as string) + " Column");
 					result.Add(col);
 				}
 			}
@@ -774,10 +782,10 @@ class SqlServerSchemaReader : SchemaReader
 		return sysType;
 	}
 
-
-
-	const string TABLE_SQL=@"SELECT *
+	const string TABLE_SQL=@"SELECT TABLES.*,
+		DescriptionExProps.value as TABLE_DESCRIPTION
 		FROM  INFORMATION_SCHEMA.TABLES
+		OUTER APPLY fn_listextendedproperty('MS_Description', 'schema', TABLES.TABLE_SCHEMA, 'table', TABLES.TABLE_NAME, null, null) As DescriptionExProps
 		WHERE TABLE_TYPE='BASE TABLE' OR TABLE_TYPE='VIEW'
 		ORDER BY TABLE_SCHEMA, TABLE_NAME
 		";
@@ -793,8 +801,10 @@ class SqlServerSchemaReader : SchemaReader
 			CHARACTER_MAXIMUM_LENGTH AS MaxLength, 
 			DATETIME_PRECISION AS DatePrecision,
 			COLUMNPROPERTY(object_id('[' + TABLE_SCHEMA + '].[' + TABLE_NAME + ']'), COLUMN_NAME, 'IsIdentity') AS IsIdentity,
-			COLUMNPROPERTY(object_id('[' + TABLE_SCHEMA + '].[' + TABLE_NAME + ']'), COLUMN_NAME, 'IsComputed') as IsComputed
+			COLUMNPROPERTY(object_id('[' + TABLE_SCHEMA + '].[' + TABLE_NAME + ']'), COLUMN_NAME, 'IsComputed') as IsComputed,
+			DescriptionExProps.value as Description
 		FROM  INFORMATION_SCHEMA.COLUMNS
+		OUTER APPLY fn_listextendedproperty('MS_Description', 'schema', @schemaName, 'table', @tableName, 'column', COLUMN_NAME) As DescriptionExProps
 		WHERE TABLE_NAME=@tableName AND TABLE_SCHEMA=@schemaName
 		ORDER BY OrdinalPosition ASC";
 


### PR DESCRIPTION
I've added two features:
- Firstly, reads the MS_Description extended-property for columns and tables and includes that in the XML comments. (Means that if you put a description in SQL Server Management Studio, it will come through all the way into intellisense.)
- Secondly, changes the order of the tables in the model to be in alphabetical order.  (Previously, they were in undefined order, which meant any change to a table would cause the ordering of the tables to change.)  This should make it easier to compare versions of the generated model source code.

NB: This is my first attempt at working on GitHub, so let me know if I've made any missteps.
