### PR TITLE
Clean Description on columns and tables in model generator

### DIFF
--- a/Dapper.FastCRUD.ModelGenerator/Content/Models/GenericModelGenerator.tt
+++ b/Dapper.FastCRUD.ModelGenerator/Content/Models/GenericModelGenerator.tt
@@ -207,7 +207,8 @@ static Func<string, string> CleanUp = (str) =>
 // about multiple lines.
 static string CleanDescription(string str)
 {
-    const string oneSpace = " ";
+    const int maxLength = 140;
+	const string oneSpace = " ";
     const string twoSpaces = oneSpace + oneSpace;
     if (str == null) { return str; } // Don't process nulls
     str = str.Replace("\r", oneSpace).Replace("\n", oneSpace).Replace("\t", oneSpace);

--- a/Dapper.FastCRUD.ModelGenerator/Content/Models/GenericModelGenerator.tt
+++ b/Dapper.FastCRUD.ModelGenerator/Content/Models/GenericModelGenerator.tt
@@ -201,6 +201,24 @@ static Func<string, string> CleanUp = (str) =>
     return str;
 };
 
+// Puts all text on one line, converts tabs to spaces, removes duplicate
+// spaces. This stops the XML comment generation going wrong if there is
+// a newline in the description and Intellisense doesn't seem to care
+// about multiple lines.
+static string CleanDescription(string str)
+{
+    const string oneSpace = " ";
+    const string twoSpaces = oneSpace + oneSpace;
+    if (str == null) { return str; } // Don't process nulls
+    str = str.Replace("\r", oneSpace).Replace("\n", oneSpace).Replace("\t", oneSpace);
+    while (str.Contains(twoSpaces)) {
+        str = str.Replace(twoSpaces, oneSpace);
+    }
+    str = str.Trim(); // remove any leading/trailing whitespace
+    str = str.Substring(0, str.Length > maxLength ? maxLength : str.Length);
+    return str;
+}
+
 string CheckNullable(Column col)
 {
     string result="";
@@ -517,16 +535,16 @@ class SqlServerSchemaReader : SchemaReader
 			{
 				while(rdr.Read())
 				{
-					Table tbl=new Table();
-					tbl.Name=rdr["TABLE_NAME"].ToString();
-					tbl.Schema=rdr["TABLE_SCHEMA"].ToString();
-					tbl.IsView=string.Compare(rdr["TABLE_TYPE"].ToString(), "View", true)==0;
-					tbl.CleanName=CleanUp(tbl.Name);
-					if(tbl.CleanName.StartsWith("tbl_")) tbl.CleanName = tbl.CleanName.Replace("tbl_",""); 
-					if(tbl.CleanName.StartsWith("tbl")) tbl.CleanName = tbl.CleanName.Replace("tbl",""); 
-					tbl.CleanName = tbl.CleanName.Replace("_","");
-					tbl.ClassName=Singularize(RemoveTablePrefixes(tbl.CleanName));
-					tbl.Description=rdr["TABLE_DESCRIPTION"] as string;
+					Table tbl = new Table();
+					tbl.Name = rdr["TABLE_NAME"].ToString();
+					tbl.Schema = rdr["TABLE_SCHEMA"].ToString();
+					tbl.IsView = string.Compare(rdr["TABLE_TYPE"].ToString(), "View", true) == 0;
+					tbl.CleanName = CleanUp(tbl.Name);
+					if (tbl.CleanName.StartsWith("tbl_")) tbl.CleanName = tbl.CleanName.Replace("tbl_", "");
+					if (tbl.CleanName.StartsWith("tbl")) tbl.CleanName = tbl.CleanName.Replace("tbl", "");
+					tbl.CleanName = tbl.CleanName.Replace("_", "");
+					tbl.ClassName = Singularize(RemoveTablePrefixes(tbl.CleanName));
+					tbl.Description = CleanDescription(rdr["TABLE_DESCRIPTION"] as string);
 
 					result.Add(tbl);
 				}
@@ -603,8 +621,8 @@ class SqlServerSchemaReader : SchemaReader
 					col.PropertyType=GetPropertyType(rdr["DataType"].ToString());
 					col.IsNullable=rdr["IsNullable"].ToString()=="YES";
 					col.IsAutoIncrement=((int)rdr["IsIdentity"])==1;
-					col.IsGeneratedUniqueIdentifier = rdr["DefaultSetting"].ToString().ToLower().Trim(' ','(',')')=="newid";
-					col.Description = rdr["Description"] as string ?? ((rdr["ColumnName"] as string) + " Column");
+					col.IsGeneratedUniqueIdentifier = rdr["DefaultSetting"].ToString().ToLower().Trim(' ', '(', ')') == "newid";
+					col.Description = CleanDescription(rdr["Description"] as string) ?? ((rdr["ColumnName"] as string) + " Column");
 					result.Add(col);
 				}
 			}

--- a/Dapper.FastCrud.Tests/Models/ModelGeneratorConfig.tt
+++ b/Dapper.FastCrud.Tests/Models/ModelGeneratorConfig.tt
@@ -12,10 +12,10 @@ This is the configuration file for GenericModelGenerator.tt
 	ClassSuffix = "";
     IncludeViews = true;
     IncludeRelationships = true;
-	IgnoreColumnDefaultValues = false; 
+	IgnoreColumnDefaultValues = false;
 	ExcludeTablePrefixes = new string[]{"ELMAH", "AspNet_", "dtproperties", "NormalizedUsageLog", "HangFire.", "Building"};
 #>
-<#@ include file="..\..\NuGetSpecs\GenericModelGenerator.tt" #>
+<#@ include file="..\..\Dapper.FastCRUD.ModelGenerator\Content\Models\GenericModelGenerator.tt" #>
 <#+
 	void ConfigureTableMappings(Tables tables){
 		/*


### PR DESCRIPTION
Resolves an issue in the previous xml comment code where it choked if the description in the database had multiple lines.

It compresses whitespace (`\r` `\n` `\t` and `" "`) into a single space (to bring descriptions to one line), and truncates descriptions to 140 characters.