### PR TITLE
Support new lines in the description fields of tables and columns

### DIFF
--- a/Dapper.FastCrud.ModelGenerator/Content/Models/GenericModelGenerator.tt
+++ b/Dapper.FastCrud.ModelGenerator/Content/Models/GenericModelGenerator.tt
@@ -42,7 +42,7 @@ foreach(Table tbl in tables.Where(t=> !t.Ignore)){
 		if(IsExcluded(tbl.Schema, tbl.Name, ExcludeTablePrefixes)) continue;
 #>
     /// <summary>
-    /// Represents the <#=tbl.Name#> <#=(tbl.IsView)?"view":"table"#><#=String.IsNullOrEmpty(tbl.Description)?"":" ("+tbl.Description+")"#>.
+    /// Represents the <#=tbl.Name#> <#=(tbl.IsView)?"view":"table"#><#=String.IsNullOrEmpty(tbl.Description)?"":" ("+tbl.Description.Replace(Environment.NewLine, " ")+")"#>.
     /// </summary>
 	[Table("<#=tbl.Name#>")]
 	public partial class <#=tbl.ClassName#>
@@ -50,7 +50,7 @@ foreach(Table tbl in tables.Where(t=> !t.Ignore)){
 <#foreach(Column col in from c in tbl.Columns where !c.Ignore select c)
 {#>
 		/// <summary>
-		/// <#=col.Description#>
+		/// <#=col.Description.Replace(Environment.NewLine, " ")#>
 		/// </summary>
 	<#
 	if (col.IsPK) { #>


### PR DESCRIPTION
Allow new line characters on the database description fields, and properly replace the new line characters by an empty space when generating the class/property summary comments.

If this is not done, the generated cs file will be invalid, if there are any database comments with new lines.