### PR TITLE
Updated Depencies to build with .Net Framework v4.6.1 and .Net Standa…

### DIFF
--- a/Dapper.FastCrud.Benchmarks/Dapper.FastCrud.Benchmarks.csproj
+++ b/Dapper.FastCrud.Benchmarks/Dapper.FastCrud.Benchmarks.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dapper.FastCrud.Benchmarks</RootNamespace>
     <AssemblyName>Dapper.FastCrud.Benchmarks</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Dapper.FastCrud.ModelGenerator/Dapper.FastCrud.ModelGenerator.csproj
+++ b/Dapper.FastCrud.ModelGenerator/Dapper.FastCrud.ModelGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AssemblyTitle>Dapper.FastCrud.ModelGenerator</AssemblyTitle>
     <AssemblyName>Dapper.FastCrud.ModelGenerator</AssemblyName>	
 	<GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/Dapper.FastCrud.Tests/Dapper.FastCrud.Tests.csproj
+++ b/Dapper.FastCrud.Tests/Dapper.FastCrud.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dapper.FastCrud.Tests</RootNamespace>
     <AssemblyName>Dapper.FastCrud.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Dapper.FastCrud/Dapper.FastCrud.csproj
+++ b/Dapper.FastCrud/Dapper.FastCrud.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AssemblyTitle>Dapper.FastCrud</AssemblyTitle>
     <AssemblyName>Dapper.FastCrud</AssemblyName>
 	<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -34,27 +34,28 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.2" />
+    <PackageReference Include="Dapper" Version="1.50.5" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="StringInterpolationBridge" Version="0.9.1" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
      <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <DefineConstants>$(DefineConstants);NET_46_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);COREFX</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
…rd v2.0 so this NuGet package can be used in .Net Core v2.1

Updated Depencies :
    Dapper.FastCrud.csproj
        Dapper to v1.50.2 to v1.50.5
        Updated targetFramework .Net 46 or .Net 45 to .Net v4.6.1.
        Updated targetFramework .Net v1.6 to .Net v2.0

    Dapper.FastCrud.Benchmarks.csproj
    Updated Depencies :
        Updated targetFramework .Net version 4.5.2 to 4.6.1

    Dapper.FastCrud.ModelGenerator.csproj
    Updated Depencies :
        Updated targetFramework .Net 45 to .Net v4.6.1.
        Updated targetFramework .Net v1.6 to .Net v2.0

    Dapper.FastCrud.Tests.csproj
    Updated Depencies :
        Updated targetFramework .Net 46 or .Net 45 to .Net v4.6.1.

UnitTest:
133 UnitTests failed when I forked the project. The same 133 unitTest fail after my changes.